### PR TITLE
add profiler and change compile backend for my old GPU

### DIFF
--- a/train.py
+++ b/train.py
@@ -26,6 +26,7 @@ import numpy as np
 import torch
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.distributed import init_process_group, destroy_process_group
+from torch.profiler import profile, record_function, ProfilerActivity
 
 from model import GPTConfig, GPT
 
@@ -40,7 +41,8 @@ eval_only = False # if True, script exits right after the first eval
 always_save_checkpoint = True # if True, always save a checkpoint after each eval
 init_from = 'scratch' # 'scratch' or 'resume' or 'gpt2*'
 # wandb logging
-wandb_log = False # disabled by default
+wandb_log = True 
+#False # disabled by default
 wandb_project = 'owt'
 wandb_run_name = 'gpt2' # 'run' + str(time.time())
 # data
@@ -202,7 +204,8 @@ checkpoint = None # free up memory
 if compile:
     print("compiling the model... (takes a ~minute)")
     unoptimized_model = model
-    model = torch.compile(model) # requires PyTorch 2.0
+    model = torch.compile(model, backend="cudagraphs") # requires PyTorch 2.0
+    #['cudagraphs', 'inductor', 'onnxrt', 'openxla', 'openxla_eval', 'tvm']
 
 # wrap model into DDP container
 if ddp:
@@ -242,92 +245,111 @@ def get_lr(it):
 if wandb_log and master_process:
     import wandb
     wandb.init(project=wandb_project, name=wandb_run_name, config=config)
+    print(f"wandb_project name {wandb_project}, run_name {wandb_run_name}")
 
-# training loop
-X, Y = get_batch('train') # fetch the very first batch
-t0 = time.time()
-local_iter_num = 0 # number of iterations in the lifetime of this process
-raw_model = model.module if ddp else model # unwrap DDP container if needed
-running_mfu = -1.0
-while True:
+g = torch.cuda.CUDAGraph()
+start = time.perf_counter()
+with profile(activities=[torch.profiler.ProfilerActivity.CPU, 
+                         torch.profiler.ProfilerActivity.CUDA], 
+             record_shapes=True, 
+             profile_memory=True, 
+             #use_cuda=True
+             ) as prof:
+    # training loop
+    X, Y = get_batch('train') # fetch the very first batch
+    t0 = time.time()
+    local_iter_num = 0 # number of iterations in the lifetime of this process
+    raw_model = model.module if ddp else model # unwrap DDP container if needed
+    running_mfu = -1.0
+    while True:
 
-    # determine and set the learning rate for this iteration
-    lr = get_lr(iter_num) if decay_lr else learning_rate
-    for param_group in optimizer.param_groups:
-        param_group['lr'] = lr
+        # determine and set the learning rate for this iteration
+        lr = get_lr(iter_num) if decay_lr else learning_rate
+        for param_group in optimizer.param_groups:
+            param_group['lr'] = lr
 
-    # evaluate the loss on train/val sets and write checkpoints
-    if iter_num % eval_interval == 0 and master_process:
-        losses = estimate_loss()
-        print(f"step {iter_num}: train loss {losses['train']:.4f}, val loss {losses['val']:.4f}")
-        if wandb_log:
-            wandb.log({
+        # evaluate the loss on train/val sets and write checkpoints
+        if iter_num % eval_interval == 0 and master_process:
+            losses = estimate_loss()
+            print(f"step {iter_num}: train loss {losses['train']:.4f}, val loss {losses['val']:.4f}")
+            if wandb_log:
+                print("-> wandb")
+                wandb.log({
                 "iter": iter_num,
                 "train/loss": losses['train'],
                 "val/loss": losses['val'],
                 "lr": lr,
                 "mfu": running_mfu*100, # convert to percentage
-            })
-        if losses['val'] < best_val_loss or always_save_checkpoint:
-            best_val_loss = losses['val']
-            if iter_num > 0:
-                checkpoint = {
-                    'model': raw_model.state_dict(),
-                    'optimizer': optimizer.state_dict(),
-                    'model_args': model_args,
-                    'iter_num': iter_num,
-                    'best_val_loss': best_val_loss,
-                    'config': config,
-                }
-                print(f"saving checkpoint to {out_dir}")
-                torch.save(checkpoint, os.path.join(out_dir, 'ckpt.pt'))
-    if iter_num == 0 and eval_only:
-        break
+                })
+            if losses['val'] < best_val_loss or always_save_checkpoint:
+                best_val_loss = losses['val']
+                if iter_num > 0:
+                    checkpoint = {
+                        'model': raw_model.state_dict(),
+                        'optimizer': optimizer.state_dict(),
+                        'model_args': model_args,
+                        'iter_num': iter_num,
+                        'best_val_loss': best_val_loss,
+                        'config': config,
+                    }   
+                    print(f"saving checkpoint to {out_dir}")
+                    torch.save(checkpoint, os.path.join(out_dir, 'ckpt.pt'))
+        if iter_num == 0 and eval_only:
+            break
 
-    # forward backward update, with optional gradient accumulation to simulate larger batch size
-    # and using the GradScaler if data type is float16
-    for micro_step in range(gradient_accumulation_steps):
-        if ddp:
+        # forward backward update, with optional gradient accumulation to simulate larger batch size
+        # and using the GradScaler if data type is float16
+        for micro_step in range(gradient_accumulation_steps):
+            if ddp:
             # in DDP training we only need to sync gradients at the last micro step.
             # the official way to do this is with model.no_sync() context manager, but
             # I really dislike that this bloats the code and forces us to repeat code
             # looking at the source of that context manager, it just toggles this variable
-            model.require_backward_grad_sync = (micro_step == gradient_accumulation_steps - 1)
-        with ctx:
-            logits, loss = model(X, Y)
-            loss = loss / gradient_accumulation_steps # scale the loss to account for gradient accumulation
-        # immediately async prefetch next batch while model is doing the forward pass on the GPU
-        X, Y = get_batch('train')
-        # backward pass, with gradient scaling if training in fp16
-        scaler.scale(loss).backward()
-    # clip the gradient
-    if grad_clip != 0.0:
-        scaler.unscale_(optimizer)
-        torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
-    # step the optimizer and scaler if training in fp16
-    scaler.step(optimizer)
-    scaler.update()
-    # flush the gradients as soon as we can, no need for this memory anymore
-    optimizer.zero_grad(set_to_none=True)
+                model.require_backward_grad_sync = (micro_step == gradient_accumulation_steps - 1)
+            with ctx:
+                logits, loss = model(X, Y)
+                loss = loss / gradient_accumulation_steps # scale the loss to account for gradient accumulation
+            # immediately async prefetch next batch while model is doing the forward pass on the GPU
+            X, Y = get_batch('train')
+            # backward pass, with gradient scaling if training in fp16
+            scaler.scale(loss).backward()
+        # clip the gradient
+        if grad_clip != 0.0:
+            scaler.unscale_(optimizer)
+            torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
+        # step the optimizer and scaler if training in fp16
+        scaler.step(optimizer)
+        scaler.update()
+        # flush the gradients as soon as we can, no need for this memory anymore
+        optimizer.zero_grad(set_to_none=True)
 
-    # timing and logging
-    t1 = time.time()
-    dt = t1 - t0
-    t0 = t1
-    if iter_num % log_interval == 0 and master_process:
-        # get loss as float. note: this is a CPU-GPU sync point
-        # scale up to undo the division above, approximating the true total loss (exact would have been a sum)
-        lossf = loss.item() * gradient_accumulation_steps
-        if local_iter_num >= 5: # let the training loop settle a bit
-            mfu = raw_model.estimate_mfu(batch_size * gradient_accumulation_steps, dt)
-            running_mfu = mfu if running_mfu == -1.0 else 0.9*running_mfu + 0.1*mfu
-        print(f"iter {iter_num}: loss {lossf:.4f}, time {dt*1000:.2f}ms, mfu {running_mfu*100:.2f}%")
-    iter_num += 1
-    local_iter_num += 1
+        # timing and logging
+        t1 = time.time()
+        dt = t1 - t0
+        t0 = t1
+        if iter_num % log_interval == 0 and master_process:
+            # get loss as float. note: this is a CPU-GPU sync point
+            # scale up to undo the division above, approximating the true total loss (exact would have been a sum)
+            lossf = loss.item() * gradient_accumulation_steps
+            if local_iter_num >= 5: # let the training loop settle a bit
+                mfu = raw_model.estimate_mfu(batch_size * gradient_accumulation_steps, dt)
+                running_mfu = mfu if running_mfu == -1.0 else 0.9*running_mfu + 0.1*mfu
+            print(f"iter {iter_num}: loss {lossf:.4f}, time {dt*1000:.2f}ms, mfu {running_mfu*100:.2f}%")
+        iter_num += 1
+        local_iter_num += 1
 
-    # termination conditions
-    if iter_num > max_iters:
-        break
+        # termination conditions
+        if iter_num > max_iters:
+            break
 
-if ddp:
-    destroy_process_group()
+    if ddp:
+        destroy_process_group()
+
+total_runtime = time.perf_counter() - start
+prof.export_chrome_trace(f"trace_compile{compile}.json")
+print(prof.key_averages().table(sort_by="cpu_memory_usage", row_limit=10))
+print(prof.key_averages().table(sort_by="cuda_time_total", row_limit=10))
+
+print(f"total runtime {total_runtime}")
+
+


### PR DESCRIPTION
torch compile
```python train.py config/train_shakespeare_char.py --device=cuda --compile=True  --eval_iters=20 --log_interval=1 --block_size=64 --batch_size=12 --n_layer=4 --n_head=4 --n_embd=128 --max_iters=200 --lr_decay_iters=10 --dropout=0.0```
```
iter 0: loss 4.1828, time 7961.94ms, mfu -100.00% <- huge
iter 1: loss 4.1511, time 248.63ms, mfu -100.00% 
iter 2: loss 4.1654, time 23.37ms, mfu -100.00%  
iter 3: loss 4.1398, time 22.15ms, mfu -100.00%
iter 4: loss 4.0927, time 22.29ms, mfu -100.00%
iter 5: loss 4.0367, time 25.98ms, mfu 0.05%
iter 6: loss 3.9745, time 21.94ms, mfu 0.05%
iter 7: loss 3.9021, time 22.30ms, mfu 0.05%
iter 8: loss 3.8626, time 21.99ms, mfu 0.05% <- steady state looks 1.5~2X faster. compared to no compile version
iter 9: loss 3.7704, time 21.84ms, mfu 0.05%
iter 10: loss 3.7665, time 21.83ms, mfu 0.05%
iter 11: loss 3.7466, time 22.57ms, mfu 0.05%
iter 12: loss 3.7263, time 22.12ms, mfu 0.05%
iter 13: loss 3.6981, time 21.90ms, mfu 0.05%
```
total runtime 54.8s

no compile
```
python train.py config/train_shakespeare_char.py --device=cuda --compile=False  --eval_iters=20 --log_interval=1 --block_size=64 --batch_size=12 --n_layer=4 --n_head=4 --n_embd=128 --max_iters=200 --lr_decay_iters=10 --dropout=0.0
```
```
ter 0: loss 4.1828, time 1166.17ms, mfu -100.00%
iter 1: loss 4.1511, time 40.38ms, mfu -100.00%
iter 2: loss 4.1654, time 36.99ms, mfu -100.00%
iter 3: loss 4.1398, time 35.56ms, mfu -100.00%
iter 4: loss 4.0927, time 33.93ms, mfu -100.00%
iter 5: loss 4.0367, time 35.60ms, mfu 0.04%
iter 6: loss 3.9745, time 37.23ms, mfu 0.04%
iter 7: loss 3.9021, time 36.91ms, mfu 0.04%
iter 8: loss 3.8626, time 32.95ms, mfu 0.04%
iter 9: loss 3.7704, time 43.00ms, mfu 0.04%
iter 10: loss 3.7665, time 32.80ms, mfu 0.04%
iter 11: loss 3.7466, time 38.99ms, mfu 0.04%
iter 12: loss 3.7263, time 33.67ms, mfu 0.04%
iter 13: loss 3.6981, time 36.44ms, mfu 0.04%
```

total runtime 76.5s
